### PR TITLE
Fix error in python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ console.log("height = " + g.logicalScreen().imageHeight());
 
 ```python
 g = Gif.from_file("path/to/some.gif")
-print "width = %d" % (g.logical_screen.image_width)
-print "height = %d" % (g.logical_screen.image_height)
+print "width = %d" % (g.logical_screen_descriptor.screen_width)
+print "height = %d" % (g.logical_screen_descriptor.screen_height)
 ```
 
 ### In Ruby


### PR DESCRIPTION
I tried the example code in Python and it didn't work. So I listed all the attributes using `dir(g)` and found that there was no `logical_screen` attribute and instead found the correct ones.
Please correct me if I am wrong.