### PR TITLE
travis yaml: added python pip cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ scala:
 cache:
   directories:
     - $HOME/.ivy2
+    - $HOME/.cache/pip
 
 addons:
   apt:


### PR DESCRIPTION
I am no expert on Travis, so I dont know if this actually improves anything or not, just submitting for your consideration. Perhaps other directories should/could also be cached? 
