### PR TITLE
Add C++ usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,31 @@ blocks: first comes `header` and then comes `logical_screen`:
   * `flags`, `bg_color_index` and `pixel_aspect_ratio` take 1-byte
     unsigned int each
 
-This `.ksy` file can be compiled it into `Gif.cs` / `Gif.java` /
+This `.ksy` file can be compiled it into `gif.cpp` / `Gif.cs` / `Gif.java` /
 `Gif.js` / `gif.py` / `gif.rb` and then instantly one can load .gif
 file and access, for example, it's width and height.
+
+### In C++
+
+See [C++/STL notes in the documentation](http://doc.kaitai.io/lang_cpp_stl.html) for a more complete quick start guide.
+
+```cpp
+#include <fstream>
+#include <kaitai/kaitaistream.h>
+#include <iostream>
+#include "gif.h"
+
+int main() {
+    std::ifstream is("my.gif", std::ifstream::binary);
+    kaitai::kstream ks(&is);
+    gif_t* data = new gif_t(&ks);
+
+    std::cout << "width = " << data->logical_screen()->image_width() << std::endl;
+    std::cout << "height = " << data->logical_screen()->image_height() << std::endl;
+
+    return 0;
+}
+```
 
 ### In C\#
 

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ See [C++/STL notes in the documentation](http://doc.kaitai.io/lang_cpp_stl.html)
 int main() {
     std::ifstream is("my.gif", std::ifstream::binary);
     kaitai::kstream ks(&is);
-    gif_t* data = new gif_t(&ks);
+    gif_t* g = new gif_t(&ks);
 
-    std::cout << "width = " << data->logical_screen()->image_width() << std::endl;
-    std::cout << "height = " << data->logical_screen()->image_height() << std::endl;
+    std::cout << "width = " << g->logical_screen()->image_width() << std::endl;
+    std::cout << "height = " << g->logical_screen()->image_height() << std::endl;
 
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ more insights.
 Official Kaitai Struct [compiler] now supports compiling `.ksy` into
 source modules for the following languages:
 
+* C++
 * C#
 * Java
 * JavaScript


### PR DESCRIPTION
It's tested under Windows 10 64-bit with the `g++` compiler 8.3.0. It worked, but I had to get [`endian.h`](https://github.com/mikepb/endian.h/blob/0f885cbba627efe9b8f763e1c2872e904fe0c0b1/endian.h) and [`byteswap.h`](https://github.com/icecoobe/sbc-windows/blob/8e8028a98d87538245aba7d1baad88c37b4f4b74/byteswap.h) from the internet, because they're not available on Windows and the C++ runtime relies on them. Maybe the runtime should be fixed to support Windows out-of-the-box as well.