### PR TITLE
Trigger ide.kaitai.io/devel rebuild after NPM publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,12 +45,9 @@ jobs:
           NPM_API_KEY: ${{ secrets.NPM_TOKEN }}
 
       - name: trigger rebuild of ide.kaitai.io/devel
-        uses: octokit/request-action@v2.3.1
+        run: ./trigger-kaitai_struct_webide
         env:
           GITHUB_TOKEN: ${{ secrets.KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN }}
-        with:
-          route: POST /repos/kaitai-io/kaitai_struct_webide/dispatches
-          event_type: rebuild-webide # this value is required but unused
 
       - name: publish ksc to artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: trigger rebuild of ide.kaitai.io/devel
         run: ./trigger-kaitai_struct_webide
         env:
-          GITHUB_TOKEN: ${{ secrets.KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN }}
+          KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN: ${{ secrets.KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN }}
 
       - name: publish ksc to artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,14 @@ jobs:
         env:
           NPM_API_KEY: ${{ secrets.NPM_TOKEN }}
 
+      - name: trigger rebuild of ide.kaitai.io/devel
+        uses: octokit/request-action@v2.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN }}
+        with:
+          route: POST /repos/kaitai-io/kaitai_struct_webide/dispatches
+          event_type: rebuild-webide # this value is required but unused
+
       - name: publish ksc to artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,8 @@ jobs:
           NPM_API_KEY: ${{ secrets.NPM_TOKEN }}
 
       - name: trigger rebuild of ide.kaitai.io/devel
-        run: ./trigger-kaitai_struct_webide
+        run: |
+          ./trigger-kaitai_struct_webide "$(jq -r .version compiler/js/npm/package.json)"
         env:
           KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN: ${{ secrets.KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN }}
 

--- a/trigger-kaitai_struct_webide
+++ b/trigger-kaitai_struct_webide
@@ -20,4 +20,5 @@ if [ -n "$KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN" ]; then
 		"https://api.github.com/repos/$PROJECT/dispatches"
 else
 	echo "No KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN found!"
+	exit 1
 fi

--- a/trigger-kaitai_struct_webide
+++ b/trigger-kaitai_struct_webide
@@ -1,31 +1,23 @@
 #!/bin/sh -ef
 
-# https://travis-ci.com/kaitai-io/kaitai_struct_webide needs to be
-# rebuilt after we publish newest JS build of ksc to npm.
+# ide.kaitai.io/devel needs to be rebuilt after we publish newest JS build of ksc to npm.
 
 PROJECT='kaitai-io/kaitai_struct_webide'
-SLUG=$(echo "$PROJECT" | sed 's,/,%2F,g')
 
 echo "Triggering build for $PROJECT project..."
-if [ -n "$KAITAI_STRUCT_WEBIDE_TOKEN" ]; then
-	body='
-	{
-		"request": {
-			"message": "Build with kaitai-struct-compiler v'"$KAITAI_STRUCT_VERSION"'",
-			"branch": "master"
-		}
-	}
-	'
+if [ -n "$KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN" ]; then
+	# Matches the type in kaitai_struct_webide's repository_dispatch trigger
+	body='{"event_type":"rebuild"}'
 
 	echo "$body"
 
 	curl -v -fsSL \
-		-H "Content-Type: application/json" \
-		-H "Accept: application/json" \
-		-H "Travis-API-Version: 3" \
-		-H "Authorization: token $KAITAI_STRUCT_WEBIDE_TOKEN" \
+		-X POST \
+		-H "Accept: application/vnd.github+json" \
+		-H "Authorization: Bearer $KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN" \
+		-H "X-GitHub-Api-Version: 2022-11-28" \
 		-d "$body" \
-		"https://api.travis-ci.com/repo/$SLUG/requests"
+		"https://api.github.com/repos/kaitai-io/kaitai_struct_webide/dispatches"
 else
-	echo "No KAITAI_STRUCT_WEBIDE_TOKEN found!"
+	echo "No KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN found!"
 fi

--- a/trigger-kaitai_struct_webide
+++ b/trigger-kaitai_struct_webide
@@ -1,18 +1,25 @@
 #!/bin/sh -ef
 
-# ide.kaitai.io/devel needs to be rebuilt after we publish newest JS build of ksc to npm.
+# ide.kaitai.io/devel needs to be rebuilt after we publish the latest JS build of KSC to npm.
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <ksc_version>"
+    exit 1
+fi
+
+ksc_version=$1
 
 PROJECT='kaitai-io/kaitai_struct_webide'
 
 echo "Triggering build for $PROJECT project..."
 if [ -n "$KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN" ]; then
-	# Matches the type in kaitai_struct_webide's repository_dispatch trigger
-	body='{"event_type":"rebuild"}'
+	# `event_type` must match the name whitelisted in the CI workflow config in
+	# https://github.com/kaitai-io/kaitai_struct_webide
+	body=$(jq -n -c --arg ksc_version "$ksc_version" '{event_type: "rebuild", client_payload: {ksc_version: $ksc_version}}')
 
-	echo "$body"
+	printf '%s\n' "$body"
 
-	curl -v -fsSL \
-		-X POST \
+	curl -fsSL \
 		-H "Accept: application/vnd.github+json" \
 		-H "Authorization: Bearer $KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN" \
 		-H "X-GitHub-Api-Version: 2022-11-28" \

--- a/trigger-kaitai_struct_webide
+++ b/trigger-kaitai_struct_webide
@@ -17,7 +17,7 @@ if [ -n "$KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN" ]; then
 		-H "Authorization: Bearer $KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN" \
 		-H "X-GitHub-Api-Version: 2022-11-28" \
 		-d "$body" \
-		"https://api.github.com/repos/kaitai-io/kaitai_struct_webide/dispatches"
+		"https://api.github.com/repos/$PROJECT/dispatches"
 else
 	echo "No KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN found!"
 fi


### PR DESCRIPTION
Triggers the kaitai_struct_webide workflow to re-run (see https://github.com/kaitai-io/kaitai_struct_webide/pull/181) after the NPM publish step.

This will require adding a [repository secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) to the `kaitai_struct` repo named `KAITAI_STRUCT_WEBIDE_GITHUB_TOKEN`, which should hold a github access token with `contents: write` permissions on the `kaitai_struct_webide` repo, allowing it to trigger the workflow. (See more about token permissions on [this third-party action's readme](https://github.com/marketplace/actions/repository-dispatch#token).)